### PR TITLE
Use goreleaser to generate homebrew formula

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,3 +27,10 @@ changelog:
     exclude:
     - '^docs:'
     - '^test:'
+brews:
+- github:
+    owner: equinox
+    name: homebrew-transparencylog
+  homepage: "https://www.transparencylog.com/"
+  folder: Formula
+  description: "verify https assets with a public transparency log"


### PR DESCRIPTION
This can be edited to customize it more if you want. https://goreleaser.com/customization/homebrew/

By default this will allow macOS and Linux (x86, x86_64, and arm) to use brew instead of needing rpms or debs. You should still provide those too but this will make install and updating on Linux easier.

If you automate the deployment in Github actions just make sure the actions have access to commit code into the equinox org.